### PR TITLE
Fetch hostkeys securely from launched instances

### DIFF
--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -670,6 +670,11 @@ Optional configuration keys
     Only supported when the cloud provider is `google`.
     Only supported value is `preemptible`.
 
+``ssh_hostkeys_from_console_output``
+
+    whether to retrieve SSH host keys from instances´ console output,
+    instead of accepting the host keys without verification when connecting
+    via SSH for the first time.
 
 Examples
 --------

--- a/elasticluster/conf.py
+++ b/elasticluster/conf.py
@@ -451,6 +451,7 @@ class ConfigValidator(object):
         schema = {"cluster": {"cloud": All(str, Length(min=1)),
                               "setup_provider": All(str, Length(min=1)),
                               "login": All(str, Length(min=1)),
+                              Optional("ssh_hostkeys_from_console_output"): Boolean(str),
                           },
                   "setup": {"provider": All(str, Length(min=1)),
                             Optional("playbook_path"): can_read_file(),

--- a/elasticluster/providers/__init__.py
+++ b/elasticluster/providers/__init__.py
@@ -88,6 +88,16 @@ class AbstractCloudProvider:
         """
         pass
 
+    @abstractmethod
+    def get_console_output(self, instance_id):
+        """Returns an instance's console output.
+
+        :param str instance_id: instance identifier
+
+        :return: str - instance console output
+        """
+        pass
+
 
 class AbstractSetupProvider:
     """

--- a/elasticluster/providers/ec2_boto.py
+++ b/elasticluster/providers/ec2_boto.py
@@ -268,6 +268,9 @@ class BotoCloudProvider(AbstractCloudProvider):
         instance = self._load_instance(instance_id)
 
         if instance.update() == "running":
+            output = instance.get_console_output()
+            if not output.output:
+                return False
             # If the instance is up&running, ensure it has an IP
             # address.
             if not instance.ip_address and self.request_floating_ip:
@@ -278,6 +281,11 @@ class BotoCloudProvider(AbstractCloudProvider):
             return True
         else:
             return False
+
+    def get_console_output(self, instance_id):
+        instance = self._load_instance(instance_id)
+        instance.update()
+        return instance.get_console_output().output
 
     def _allocate_address(self, instance):
         """Allocates a free public ip address to the given instance

--- a/elasticluster/providers/openstack.py
+++ b/elasticluster/providers/openstack.py
@@ -191,6 +191,11 @@ class OpenStackCloudProvider(AbstractCloudProvider):
         instance = self._load_instance(instance_id, force_reload=True)
         return instance.status == 'ACTIVE'
 
+    def get_console_output(self, instance_id):
+        instance = self._load_instance(instance_id)
+        instance.update()
+        return instance.get_console_output()
+
     # Protected methods
 
     def _check_keypair(self, name, public_key_path, private_key_path):


### PR DESCRIPTION
Closes #144.

I took the liberty to update the code from @jwm to work on `master`, although there are some slight changes. I tried to take your feedback into account. I also implemented the option for OpenStack. I have no way to test EC2 at the moment, so I just included the changes to `ec2_boto` as they were in @jwm 's patch.

It works on our OpenStack instance, further testing and feedback welcome, as I'm still not all to deep into the code.

Best,

Manuel
