### PR TITLE
Implement availability zone support for OpenStack.

### DIFF
--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -495,6 +495,11 @@ Valid configuration keys for ``openstack``
   is set, this option is ignored and the value of the environment
   variable is used instead.
 
+``availability_zone``
+  If this is given, all cluster nodes will be started in this
+  availability zone. Otherwise (default), no request w.r.t. AZ will be
+  made to the OpenStack APIs.
+
 ``identity_api_version``
   Force use of the OpenStack Identity ("Keystone") API v2 or v3.  (Use
   the values ``2`` or ``3`` respectively.)  If this configuration item

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -500,6 +500,12 @@ Valid configuration keys for ``openstack``
   availability zone. Otherwise (default), no request w.r.t. AZ will be
   made to the OpenStack APIs.
 
+  .. warning::
+
+     ElastiCluster will *not* check if the availability zone name is
+     correct.  Any mis-spellings or other errors in the name will
+     result in cluster nodes not starting with an error.
+
 ``identity_api_version``
   Force use of the OpenStack Identity ("Keystone") API v2 or v3.  (Use
   the values ``2`` or ``3`` respectively.)  If this configuration item

--- a/elasticluster/conf.py
+++ b/elasticluster/conf.py
@@ -246,6 +246,7 @@ CLOUD_PROVIDER_SCHEMAS = {
         Optional("project_name"): nonempty_str,
         Optional("request_floating_ip"): boolean,  ## DEPRECATED, place in cluster or node config
         Optional("region_name"): nonempty_str,
+        Optional("availability_zone"): nonempty_str,
         Optional("compute_api_version"): Or('1.1', '2'),
         Optional("image_api_version"): Or('1', '2'),
         Optional("network_api_version"): Or('2.0'),

--- a/elasticluster/providers/openstack.py
+++ b/elasticluster/providers/openstack.py
@@ -155,7 +155,9 @@ class OpenStackCloudProvider(AbstractCloudProvider):
                  project_name=None,
                  auth_url=None,
                  user_domain_name="default", project_domain_name="default",
-                 region_name=None, storage_path=None,
+                 region_name=None,
+                 availability_zone=None,
+                 storage_path=None,
                  compute_api_version=DEFAULT_OS_COMPUTE_API_VERSION,
                  image_api_version=DEFAULT_OS_IMAGE_API_VERSION,
                  network_api_version=DEFAULT_OS_NETWORK_API_VERSION,
@@ -176,6 +178,7 @@ class OpenStackCloudProvider(AbstractCloudProvider):
         self._os_tenant_name = self._get_os_config_value('project name', project_name, ['OS_PROJECT_NAME', 'OS_TENANT_NAME'])
         self._os_project_domain_name = self._get_os_config_value('project domain name', project_domain_name, ['OS_PROJECT_DOMAIN_NAME'], 'default')
         self._os_region_name = self._get_os_config_value('region_name', region_name, ['OS_REGION_NAME'], '')
+        self.availability_zone = availability_zone
 
         # the OpenStack versioning mess
         if nova_api_version is not None:
@@ -465,6 +468,11 @@ class OpenStackCloudProvider(AbstractCloudProvider):
         self._init_os_api()
 
         vm_start_args = {}
+
+        if self.availability_zone:
+            log.debug("Starting node `%s` in availability zone `%s`.",
+                      node_name, self.availability_zone)
+            vm_start_args['availability_zone'] = self.availability_zone
 
         log.debug("Checking keypair `%s` ...", key_name)
         with OpenStackCloudProvider.__node_start_lock:


### PR DESCRIPTION
This is draft code for implementing AZ support in the OpenStack cloud backend.

To use it, add the `availability_zone` configuration key setting to the OpenStack cloud stanza:

```
[cloud/openstack]
# ... other settings stay the same ...
availability_zone = az1
```

Note that ElastiCluster will *not* verify if the AZ name is correct; any mis-spelling or wrong names will just result in nodes not starting with an error.