### PR TITLE
disable package upgrade on redhat when upgrade_packages=no

### DIFF
--- a/elasticluster/share/playbooks/roles/common/tasks/init-RedHat.yml
+++ b/elasticluster/share/playbooks/roles/common/tasks/init-RedHat.yml
@@ -51,6 +51,7 @@
     update_cache: yes
     # Very slow, especially with dkms/nvidia, and not useful for first boot.
     exclude: "kernel*"
+  when: 'upgrade_packages|default(True)|bool'
 
 
 - name: Provide workaround for https://github.com/ansible/ansible-modules-core/issues/4472


### PR DESCRIPTION
do the same as for [Debian systems](https://github.com/elasticluster/elasticluster/blob/master/elasticluster/share/playbooks/roles/common/tasks/init-Debian.yml#L67-L71)