### PR TITLE
allow to start 0 instances

### DIFF
--- a/elasticluster/cluster.py
+++ b/elasticluster/cluster.py
@@ -692,7 +692,7 @@ class Cluster(Struct):
         # finding all node groups with an unsatisfied amount of nodes
         unsatisfied = 0
         for kind, required in min_nodes.items():
-            available = len(self.nodes[kind])
+            available = len(self.nodes.get(kind, []))
             if available < required:
                 log.error(
                     "Not enough nodes of kind `%s`:"


### PR DESCRIPTION
closes #672

Hi @riccardomurri,

This PR enables defining different worker types in the config file and setting `{XXXworker}_nodes=0`, so that they are not created on `start` , but can be added later on via `resize`.

I ran some tests on openstack configuring a slurm cluster -- works as expected.
One can start 0 instances, add, and remove all instances of one class.

Note that resizing from 0 requires a template (#248)
