### PR TITLE
Anaconda: temporarily set default version to 2019.07

### DIFF
--- a/elasticluster/share/playbooks/roles/anaconda/defaults/main.yml
+++ b/elasticluster/share/playbooks/roles/anaconda/defaults/main.yml
@@ -7,7 +7,7 @@
 anaconda_mirror : 'http://repo.continuum.io/archive'
 
 # Version of the Anaconda distribution to install
-anaconda_version : '2019.10'
+anaconda_version : '2019.07'
 
 # Anaconda comes with either a Python2 or a Python3 interpreter
 # -- choose which one you want here.


### PR DESCRIPTION
Bug: https://github.com/ContinuumIO/anaconda-issues/issues/11466#
The latest Anaconda installer (2019.10) has a bug that affects virtual machine with one vcpu: the configuration of a cluster keeps hanging at the Anaconda installation step.
The issue has been reproduced by manually running the Anaconda installer on the partially configured VM, with the installation hanging at the "Unpacking payload" step as per bug report.

This pull request addresses the issue setting the default version of Anaconda to the older 2019.07 until an updated release is available.

References:
https://github.com/ContinuumIO/anaconda-issues/issues/11466#issuecomment-568483600
