### PR TITLE
GridEngine: Use `qconf -Mp` when PE already exists

### DIFF
--- a/elasticluster/share/playbooks/roles/gridengine-master/tasks/main.yml
+++ b/elasticluster/share/playbooks/roles/gridengine-master/tasks/main.yml
@@ -208,7 +208,7 @@
     - gridengine
     - gridengine-master
   shell: |
-    bash -lc '(qconf -spl | fgrep -q "{{item}}") || qconf -Ap {{SGE_ROOT}}/{{item}}.pe.conf'
+    bash -lc 'if (qconf -spl | fgrep -q "{{item}}"); then qconf -Mp {{SGE_ROOT}}/{{item}}.pe.conf; else qconf -Ap {{SGE_ROOT}}/{{item}}.pe.conf; fi'
   loop:
     # keep in sync with the contents of `all.q.conf`!
     - make


### PR DESCRIPTION
Use `qconf`'s `-Ap` or `-Mp` depending on whether the named PE already exists or not.

Many thanks to @a1an77 for reporting the issue and suggesting this fix!