### PR TITLE
Adding labels to GCE from command line

### DIFF
--- a/elasticluster/cluster.py
+++ b/elasticluster/cluster.py
@@ -152,6 +152,7 @@ class Cluster(Struct):
         self.start_timeout = start_timeout
         self.thread_pool_max_size = thread_pool_max_size
         self.user_key_name = user_key_name
+        self.labels=self.params.labels
         if repository is not None:
             self.repository = repository
         else:
@@ -358,11 +359,10 @@ class Cluster(Struct):
                 'user_key_name',
                 'user_key_private',
                 'user_key_public',
-                'labels',
         ):
             if attr not in extra:
                 extra[attr] = getattr(self, attr)
-
+        extra['labels'] = self.labels
         if not name:
             # `extra` contains key `kind` already
             name = self._naming_policy.new(**extra)

--- a/elasticluster/cluster.py
+++ b/elasticluster/cluster.py
@@ -141,6 +141,7 @@ class Cluster(Struct):
                  ssh_probe_timeout=5,
                  ssh_proxy_command='',
                  thread_pool_max_size=10,
+                 labels=None,
                  **extra):
         self.name = name
         self.template = extra.pop('template', None)
@@ -152,7 +153,8 @@ class Cluster(Struct):
         self.start_timeout = start_timeout
         self.thread_pool_max_size = thread_pool_max_size
         self.user_key_name = user_key_name
-        
+        self.labels=labels
+
         if repository is not None:
             self.repository = repository
         else:

--- a/elasticluster/cluster.py
+++ b/elasticluster/cluster.py
@@ -433,7 +433,7 @@ class Cluster(Struct):
             except ValueError:
                 raise NodeNotFound("Node %s not found in cluster" % node.name)
 
-    def start(self, min_nodes=None, max_concurrent_requests=0):
+    def start(self, min_nodes=None, max_concurrent_requests=0, labels=None):
         """
         Starts up all the instances in the cloud.
 
@@ -475,9 +475,9 @@ class Cluster(Struct):
                     " will start nodes sequentially...")
                 max_concurrent_requests = 1
         if max_concurrent_requests > 1:
-            nodes = self._start_nodes_parallel(nodes, max_concurrent_requests)
+            nodes = self._start_nodes_parallel(nodes, max_concurrent_requests, labels=labels)
         else:
-            nodes = self._start_nodes_sequentially(nodes)
+            nodes = self._start_nodes_sequentially(nodes, labels=labels)
 
         # checkpoint cluster state
         self.repository.save_or_update(self)
@@ -505,7 +505,7 @@ class Cluster(Struct):
         # reachable. Raise `ClusterSizeError()` if not.
         self._check_cluster_size(self._compute_min_nodes(min_nodes))
 
-    def _start_nodes_sequentially(self, nodes):
+    def _start_nodes_sequentially(self, nodes, labels=None):
         """
         Start the nodes sequentially without forking.
 
@@ -514,14 +514,14 @@ class Cluster(Struct):
         log.debug("Note: will *not* issue parallel requests to cloud API.")
         started_nodes = set()
         for node in copy(nodes):
-            started = self._start_node(node)
+            started = self._start_node(node, labels=labels)
             if started:
                 started_nodes.add(node)
             # checkpoint cluster state
             self.repository.save_or_update(self)
         return started_nodes
 
-    def _start_nodes_parallel(self, nodes, max_thread_pool_size):
+    def _start_nodes_parallel(self, nodes, max_thread_pool_size, labels=None):
         """
         Start the nodes using a pool of multiprocessing threads for speed-up.
 
@@ -550,7 +550,7 @@ class Cluster(Struct):
 
             # intercept Ctrl+C
             with sighandler(signal.SIGINT, sigint_handler):
-                result = thread_pool.map_async(self._start_node, nodes)
+                result = thread_pool.map_async(lambda x: self._start_node(x, labels=labels), nodes)
                 while not result.ready():
                     result.wait(1)
                     # check if Ctrl+C was pressed
@@ -568,7 +568,7 @@ class Cluster(Struct):
                            in zip(nodes, result.get()) if ok)
 
     @staticmethod
-    def _start_node(node):
+    def _start_node(node, labels=labels):
         """
         Start the given node VM.
 
@@ -578,6 +578,7 @@ class Cluster(Struct):
         # FIXME: the following check is not optimal yet. When a node is still
         # in a starting state, it will start another node here, since the
         # `is_alive` method will only check for running nodes (see issue #13)
+        node.labels=labels
         if node.is_alive():
             log.info("Not starting node `%s` which is already up.", node.name)
             return True
@@ -1266,7 +1267,7 @@ class Node(Struct):
 
     def __init__(self, name, cluster_name, kind, cloud_provider, user_key_public,
                  user_key_private, user_key_name, image_user, security_group,
-                 image_id, flavor, image_userdata=None, ssh_proxy_command='',
+                 image_id, flavor, image_userdata=None, ssh_proxy_command='',labels=None
                  **extra):
         self.name = name
         self.cluster_name = cluster_name
@@ -1284,6 +1285,7 @@ class Node(Struct):
         self.instance_id = extra.pop('instance_id', None)
         self.preferred_ip = extra.pop('preferred_ip', None)
         self.ips = extra.pop('ips', [])
+        self.labels=labels
         # Remove extra arguments, if defined
         for key in list(extra.keys()):
             if hasattr(self, key):

--- a/elasticluster/cluster.py
+++ b/elasticluster/cluster.py
@@ -1267,7 +1267,7 @@ class Node(Struct):
 
     def __init__(self, name, cluster_name, kind, cloud_provider, user_key_public,
                  user_key_private, user_key_name, image_user, security_group,
-                 image_id, flavor, image_userdata=None, ssh_proxy_command='',labels=None
+                 image_id, flavor, image_userdata=None, ssh_proxy_command='', labels=None,
                  **extra):
         self.name = name
         self.cluster_name = cluster_name

--- a/elasticluster/cluster.py
+++ b/elasticluster/cluster.py
@@ -358,6 +358,7 @@ class Cluster(Struct):
                 'user_key_name',
                 'user_key_private',
                 'user_key_public',
+                'labels',
         ):
             if attr not in extra:
                 extra[attr] = getattr(self, attr)

--- a/elasticluster/cluster.py
+++ b/elasticluster/cluster.py
@@ -153,7 +153,7 @@ class Cluster(Struct):
         self.start_timeout = start_timeout
         self.thread_pool_max_size = thread_pool_max_size
         self.user_key_name = user_key_name
-        self.labels=labels
+        extra["labels"]=labels
 
         if repository is not None:
             self.repository = repository
@@ -1285,7 +1285,6 @@ class Node(Struct):
         self.instance_id = extra.pop('instance_id', None)
         self.preferred_ip = extra.pop('preferred_ip', None)
         self.ips = extra.pop('ips', [])
-        self.labels=labels
         # Remove extra arguments, if defined
         for key in list(extra.keys()):
             if hasattr(self, key):
@@ -1293,6 +1292,7 @@ class Node(Struct):
         self.extra = {}
         self.extra.update(extra.pop('extra', {}))
         self.extra.update(extra)
+        self.extra["labels"]=labels
 
     def __setstate__(self, state):
         self.__dict__.update(state)

--- a/elasticluster/cluster.py
+++ b/elasticluster/cluster.py
@@ -152,7 +152,7 @@ class Cluster(Struct):
         self.start_timeout = start_timeout
         self.thread_pool_max_size = thread_pool_max_size
         self.user_key_name = user_key_name
-        self.labels=self.params.labels
+        
         if repository is not None:
             self.repository = repository
         else:

--- a/elasticluster/cluster.py
+++ b/elasticluster/cluster.py
@@ -152,7 +152,9 @@ class Cluster(Struct):
         self.start_timeout = start_timeout
         self.thread_pool_max_size = thread_pool_max_size
         self.user_key_name = user_key_name
-        
+        self.extra = {}
+        if 'labels' in extra:
+            self.extra['labels'] = extra['labels']
 
         if repository is not None:
             self.repository = repository
@@ -183,7 +185,6 @@ class Cluster(Struct):
                 self.add_node(**node)
         self.paused_nodes = dict(extra.pop('paused_nodes', {}))
 
-        self.extra = {}
         # FIXME: ugly fix needed when saving and loading the same
         # cluster using json. The `extra` keywords will become a
         # single, dictionary-valued, `extra` option when calling again

--- a/elasticluster/cluster.py
+++ b/elasticluster/cluster.py
@@ -568,7 +568,7 @@ class Cluster(Struct):
                            in zip(nodes, result.get()) if ok)
 
     @staticmethod
-    def _start_node(node, labels=labels):
+    def _start_node(node, labels=None):
         """
         Start the given node VM.
 

--- a/elasticluster/cluster.py
+++ b/elasticluster/cluster.py
@@ -360,10 +360,12 @@ class Cluster(Struct):
                 'user_key_name',
                 'user_key_private',
                 'user_key_public',
-                'labels',
         ):
             if attr not in extra:
                 extra[attr] = getattr(self, attr)
+
+        if 'labels' in self.extra:
+            extra['labels']=self.extra['labels']
 
         if not name:
             # `extra` contains key `kind` already

--- a/elasticluster/cluster.py
+++ b/elasticluster/cluster.py
@@ -475,9 +475,9 @@ class Cluster(Struct):
                     " will start nodes sequentially...")
                 max_concurrent_requests = 1
         if max_concurrent_requests > 1:
-            nodes = self._start_nodes_parallel(nodes, max_concurrent_requests, labels=labels)
+            nodes = self._start_nodes_parallel(nodes, max_concurrent_requests, labels=self.labels)
         else:
-            nodes = self._start_nodes_sequentially(nodes, labels=labels)
+            nodes = self._start_nodes_sequentially(nodes, labels=self.labels)
 
         # checkpoint cluster state
         self.repository.save_or_update(self)
@@ -1318,9 +1318,8 @@ class Node(Struct):
         `update_ips`:meth: methods should be used to further gather details
         about the state of the node.
         """
-        labels=self.labels
         log.info("Starting node `%s` from image `%s` with flavor %s ...",
-                 self.name, self.image_id, self.flavor)
+                self.name, self.image_id, self.flavor)
         vm_data = self._cloud_provider.start_instance(
             self.user_key_name, self.user_key_public, self.user_key_private,
             self.security_group,
@@ -1328,7 +1327,6 @@ class Node(Struct):
             self.cluster_name,
             username=self.image_user,
             node_name=("%s-%s" % (self.cluster_name, self.name)),
-            labels=labels,
             **self.extra)
         if vm_data:
             assert 'instance_id' in vm_data

--- a/elasticluster/cluster.py
+++ b/elasticluster/cluster.py
@@ -1318,6 +1318,7 @@ class Node(Struct):
         `update_ips`:meth: methods should be used to further gather details
         about the state of the node.
         """
+        labels=self.labels
         log.info("Starting node `%s` from image `%s` with flavor %s ...",
                  self.name, self.image_id, self.flavor)
         vm_data = self._cloud_provider.start_instance(
@@ -1327,6 +1328,7 @@ class Node(Struct):
             self.cluster_name,
             username=self.image_user,
             node_name=("%s-%s" % (self.cluster_name, self.name)),
+            labels=labels,
             **self.extra)
         if vm_data:
             assert 'instance_id' in vm_data

--- a/elasticluster/conf.py
+++ b/elasticluster/conf.py
@@ -925,6 +925,7 @@ class Creator(object):
 
     def __init__(self, conf, storage_path=None, storage_type=None):
         self.cluster_conf = conf['cluster']
+        self.labels = conf['labels']
 
         self.storage_path = (
             os.path.expandvars(os.path.expanduser(storage_path)) if storage_path

--- a/elasticluster/conf.py
+++ b/elasticluster/conf.py
@@ -159,7 +159,7 @@ SCHEMA = {
         Optional("local_ssd_count", default=0): nonnegative_int,
         Optional("local_ssd_interface", default='SCSI'): Or('NVME', 'SCSI'),
         Optional("min_cpu_platform"): nonempty_str,
-        Optional("labels"): nonempty_str,
+        Optional("labels"): (nonempty_str, nonempty_str),
         # only on OpenStack
         Optional('floating_network_id'): str,
         Optional("request_floating_ip"): boolean,

--- a/elasticluster/conf.py
+++ b/elasticluster/conf.py
@@ -330,7 +330,7 @@ def _make_defaults_dict():
 
 ## public API entry point
 
-def make_creator(configfiles, storage_path=None):
+def make_creator(configfiles, storage_path=None, labels=None):
     """
     Return a `Creator` instance initialized from given configuration files.
 
@@ -359,7 +359,7 @@ def make_creator(configfiles, storage_path=None):
 
     config = load_config_files(configfiles)
 
-    return Creator(config, storage_path=storage_path)
+    return Creator(config, storage_path=storage_path,labels=labels)
 
 
 def _expand_config_file_list(paths, ignore_nonexistent=True,
@@ -923,9 +923,9 @@ class Creator(object):
     DEFAULT_STORAGE_PATH = os.path.expanduser("~/.elasticluster/storage")
     DEFAULT_STORAGE_TYPE = 'yaml'
 
-    def __init__(self, conf, storage_path=None, storage_type=None):
+    def __init__(self, conf, storage_path=None, storage_type=None, labels=None):
         self.cluster_conf = conf['cluster']
-        self.labels = conf['labels']
+        self.labels = labels
 
         self.storage_path = (
             os.path.expandvars(os.path.expanduser(storage_path)) if storage_path

--- a/elasticluster/conf.py
+++ b/elasticluster/conf.py
@@ -1060,6 +1060,8 @@ class Creator(object):
         extra.pop('nodes')
         extra.pop('setup')
         extra['template'] = template
+        if hasattr(self, "labels"):
+            extra["labels"]=self.labels
 
         if cloud is None:
             cloud = self.create_cloud_provider(template)
@@ -1081,6 +1083,8 @@ class Creator(object):
         nodes = conf['nodes']
         for group_name in nodes:
             group_conf = nodes[group_name]
+            if hasattr(self,"labels"):
+                group_conf["labels"] = self.labels
             for varname in ['image_user', 'image_userdata']:
                 group_conf.setdefault(varname, conf['login'][varname])
             cluster.add_nodes(group_name, **group_conf)

--- a/elasticluster/conf.py
+++ b/elasticluster/conf.py
@@ -159,6 +159,7 @@ SCHEMA = {
         Optional("local_ssd_count", default=0): nonnegative_int,
         Optional("local_ssd_interface", default='SCSI'): Or('NVME', 'SCSI'),
         Optional("min_cpu_platform"): nonempty_str,
+        Optional("labels"): nonempty_str,
         # only on OpenStack
         Optional('floating_network_id'): str,
         Optional("request_floating_ip"): boolean,
@@ -724,6 +725,7 @@ def _gather_node_kind_info(kind_name, cluster_name, cluster_conf):
             'min_cpu_platform',
             'scheduling',
             'tags',
+            'labels',
             # OpenStack only
             'floating_network_id',
             'request_floating_ip',

--- a/elasticluster/providers/gce.py
+++ b/elasticluster/providers/gce.py
@@ -440,7 +440,7 @@ class GoogleCloudProvider(AbstractCloudProvider):
             },
             'labels':{
               'items':labels,
-            }
+            },
             'scheduling': scheduling_option,
             'disks': [
                 {

--- a/elasticluster/providers/gce.py
+++ b/elasticluster/providers/gce.py
@@ -304,7 +304,7 @@ class GoogleCloudProvider(AbstractCloudProvider):
                        boot_disk_type='pd-standard',
                        boot_disk_size=10,
                        tags=None,
-                       labels=None,
+                       labels=[],
                        scheduling=None,
                        accelerator_count=0,
                        accelerator_type='default',

--- a/elasticluster/providers/gce.py
+++ b/elasticluster/providers/gce.py
@@ -438,9 +438,7 @@ class GoogleCloudProvider(AbstractCloudProvider):
             'tags': {
               'items': tags,
             },
-            'labels':{
-              'items':labels,
-            },
+            'labels':dict(labels),
             'scheduling': scheduling_option,
             'disks': [
                 {

--- a/elasticluster/subcommands.py
+++ b/elasticluster/subcommands.py
@@ -174,6 +174,7 @@ class Start(AbstractCommand):
         """
         Starts a new cluster.
         """
+        labels=self.params.labels
         cluster_template = self.params.cluster
         if self.params.cluster_name:
             cluster_name = self.params.cluster_name
@@ -197,6 +198,7 @@ class Start(AbstractCommand):
                     " in cluster template `{template}`"
                     .format(kind=kind, template=cluster_template))
             cluster_nodes_conf[kind]['num'] = num
+            cluster_nodes_conf[king]['labels']=self.params.labels
 
         # First, check if the cluster is already created.
         try:
@@ -208,7 +210,7 @@ class Start(AbstractCommand):
             except ConfigurationError as err:
                 log.error("Starting cluster %s: %s", cluster_template, err)
                 return
-        cluster.labels = self.params.labels
+        cluster.labels = labels
         try:
             print("Starting cluster `{0}` with:".format(cluster.name))
             for cls in cluster.nodes:
@@ -216,7 +218,7 @@ class Start(AbstractCommand):
             print("(This may take a while...)")
             min_nodes = dict((kind, cluster_nodes_conf[kind]['min_num'])
                              for kind in cluster_nodes_conf)
-            cluster.start(min_nodes, self.params.max_concurrent_requests)
+            cluster.start(min_nodes, self.params.max_concurrent_requests, labels=labels)
             if self.params.no_setup:
                 print("NOT configuring the cluster as requested.")
             else:

--- a/elasticluster/subcommands.py
+++ b/elasticluster/subcommands.py
@@ -210,11 +210,12 @@ class Start(AbstractCommand):
             except ConfigurationError as err:
                 log.error("Starting cluster %s: %s", cluster_template, err)
                 return
-        if cluster.hasattr(extra):
+        if hasattr(cluster,extra):
+            print("Cluster has attr extra")
             cluster.extra["labels"] = labels
         else:
             print("Cluster has no extra attr")
-            cluster.setattr("extra",{'labels':labels})
+            setattr(cluster, "extra",{'labels':labels})
         try:
             print("Starting cluster `{0}` with:".format(cluster.name))
             for cls in cluster.nodes:

--- a/elasticluster/subcommands.py
+++ b/elasticluster/subcommands.py
@@ -213,11 +213,13 @@ class Start(AbstractCommand):
                 log.error("Starting cluster %s: %s", cluster_template, err)
                 return
         if hasattr(cluster, "extra"):
-            print("Cluster has attr extra")
+            print("Cluster has attr extra+ "+str(cluster.extra))
             cluster.extra["labels"] = labels
+            print(cluster.nodes)
         else:
             print("Cluster has no extra attr")
             setattr(cluster, "extra",{'labels':labels})
+            print(cluster.nodes)
         try:
             print("Starting cluster `{0}` with:".format(cluster.name))
             for cls in cluster.nodes:

--- a/elasticluster/subcommands.py
+++ b/elasticluster/subcommands.py
@@ -145,6 +145,7 @@ class Start(AbstractCommand):
                                  'N2 of GROUP2 etc...')
         parser.add_argument('--no-setup', action="store_true", default=False,
                             help="Only start the cluster, do not configure it")
+        parser.add_argument('-l','--labels', default="billing=none,user=none", dest='labels', type=str, help="add a label for billing purposes of the form billing=xy1234,user=none")
         parser.add_argument(
             '-p', '--max-concurrent-requests', default=0,
             dest='max_concurrent_requests', type=int, metavar='NUM',

--- a/elasticluster/subcommands.py
+++ b/elasticluster/subcommands.py
@@ -200,7 +200,7 @@ class Start(AbstractCommand):
                     " in cluster template `{template}`"
                     .format(kind=kind, template=cluster_template))
             cluster_nodes_conf[kind]['num'] = num
-            cluster_nodes_conf[king]['labels']=labels
+            cluster_nodes_conf[kind]['labels']=labels
 
         # First, check if the cluster is already created.
         try:

--- a/elasticluster/subcommands.py
+++ b/elasticluster/subcommands.py
@@ -210,7 +210,7 @@ class Start(AbstractCommand):
             except ConfigurationError as err:
                 log.error("Starting cluster %s: %s", cluster_template, err)
                 return
-        
+        cluster.extra["labels"] = labels 
         try:
             print("Starting cluster `{0}` with:".format(cluster.name))
             for cls in cluster.nodes:
@@ -218,7 +218,7 @@ class Start(AbstractCommand):
             print("(This may take a while...)")
             min_nodes = dict((kind, cluster_nodes_conf[kind]['min_num'])
                              for kind in cluster_nodes_conf)
-            cluster.start(min_nodes, self.params.max_concurrent_requests, labels=labels)
+            cluster.start(min_nodes, self.params.max_concurrent_requests)
             if self.params.no_setup:
                 print("NOT configuring the cluster as requested.")
             else:

--- a/elasticluster/subcommands.py
+++ b/elasticluster/subcommands.py
@@ -208,7 +208,7 @@ class Start(AbstractCommand):
             except ConfigurationError as err:
                 log.error("Starting cluster %s: %s", cluster_template, err)
                 return
-
+        cluster.labels = cluster.params.labels
         try:
             print("Starting cluster `{0}` with:".format(cluster.name))
             for cls in cluster.nodes:

--- a/elasticluster/subcommands.py
+++ b/elasticluster/subcommands.py
@@ -176,7 +176,7 @@ class Start(AbstractCommand):
         """
         labels=self.params.labels
         print("labels="+str(labels))
-
+        print("params"+str(params))
         cluster_template = self.params.cluster
         if self.params.cluster_name:
             cluster_name = self.params.cluster_name

--- a/elasticluster/subcommands.py
+++ b/elasticluster/subcommands.py
@@ -174,7 +174,7 @@ class Start(AbstractCommand):
         """
         Starts a new cluster.
         """
-
+        print(self.params)
         cluster_template = self.params.cluster
         if self.params.cluster_name:
             cluster_name = self.params.cluster_name

--- a/elasticluster/subcommands.py
+++ b/elasticluster/subcommands.py
@@ -198,7 +198,7 @@ class Start(AbstractCommand):
                     " in cluster template `{template}`"
                     .format(kind=kind, template=cluster_template))
             cluster_nodes_conf[kind]['num'] = num
-            cluster_nodes_conf[king]['labels']=self.params.labels
+            cluster_nodes_conf[king]['labels']=labels
 
         # First, check if the cluster is already created.
         try:
@@ -210,7 +210,11 @@ class Start(AbstractCommand):
             except ConfigurationError as err:
                 log.error("Starting cluster %s: %s", cluster_template, err)
                 return
-        cluster.extra["labels"] = labels
+        if cluster.hasattr(extra):
+            cluster.extra["labels"] = labels
+        else:
+            print("Cluster has no extra attr")
+            cluster.setattr("extra",{'labels':labels})
         try:
             print("Starting cluster `{0}` with:".format(cluster.name))
             for cls in cluster.nodes:

--- a/elasticluster/subcommands.py
+++ b/elasticluster/subcommands.py
@@ -184,7 +184,7 @@ class Start(AbstractCommand):
             cluster_name = self.params.cluster
 
         creator = make_creator(self.params.config,
-                               storage_path=self.params.storage)
+                               storage_path=self.params.storage, labels=labels)
 
         if cluster_template not in creator.cluster_conf:
             raise ClusterNotFound(

--- a/elasticluster/subcommands.py
+++ b/elasticluster/subcommands.py
@@ -175,12 +175,16 @@ class Start(AbstractCommand):
         Starts a new cluster.
         """
         labels=self.params.labels
+        print("labels="+str(labels))
+
         cluster_template = self.params.cluster
         if self.params.cluster_name:
             cluster_name = self.params.cluster_name
         else:
             cluster_name = self.params.cluster
 
+        self.params.config['nodes']['labels']=labels
+        self.params.config['cluster']['labels']=labels
         creator = make_creator(self.params.config,
                                storage_path=self.params.storage)
 
@@ -210,7 +214,6 @@ class Start(AbstractCommand):
             except ConfigurationError as err:
                 log.error("Starting cluster %s: %s", cluster_template, err)
                 return
-        print("labels="+str(labels))
         if hasattr(cluster, "extra"):
             print("Cluster has attr extra")
             cluster.extra["labels"] = labels

--- a/elasticluster/subcommands.py
+++ b/elasticluster/subcommands.py
@@ -183,8 +183,6 @@ class Start(AbstractCommand):
         else:
             cluster_name = self.params.cluster
 
-        self.params.config['nodes']['labels']=labels
-        self.params.config['cluster']['labels']=labels
         creator = make_creator(self.params.config,
                                storage_path=self.params.storage)
 

--- a/elasticluster/subcommands.py
+++ b/elasticluster/subcommands.py
@@ -145,7 +145,7 @@ class Start(AbstractCommand):
                                  'N2 of GROUP2 etc...')
         parser.add_argument('--no-setup', action="store_true", default=False,
                             help="Only start the cluster, do not configure it")
-        parser.add_argument('-l','--labels', default="billing=none,user=none", dest='labels', type=str, help="add a label for billing purposes of the form billing=xy1234,user=none")
+        parser.add_argument('-l','--labels', default="billing=none,user=none", metavar='labels', dest='labels', type=str, help="add a label for billing purposes of the form billing=xy1234,user=none")
         parser.add_argument(
             '-p', '--max-concurrent-requests', default=0,
             dest='max_concurrent_requests', type=int, metavar='NUM',

--- a/elasticluster/subcommands.py
+++ b/elasticluster/subcommands.py
@@ -210,7 +210,8 @@ class Start(AbstractCommand):
             except ConfigurationError as err:
                 log.error("Starting cluster %s: %s", cluster_template, err)
                 return
-        if hasattr(cluster,"extra"):
+        print("labels="+str(labels))
+        if hasattr(cluster, "extra"):
             print("Cluster has attr extra")
             cluster.extra["labels"] = labels
         else:

--- a/elasticluster/subcommands.py
+++ b/elasticluster/subcommands.py
@@ -176,7 +176,7 @@ class Start(AbstractCommand):
         """
         labels=self.params.labels
         print("labels="+str(labels))
-        print("params"+str(params))
+        print("params"+str(self.params))
         cluster_template = self.params.cluster
         if self.params.cluster_name:
             cluster_name = self.params.cluster_name

--- a/elasticluster/subcommands.py
+++ b/elasticluster/subcommands.py
@@ -210,7 +210,7 @@ class Start(AbstractCommand):
             except ConfigurationError as err:
                 log.error("Starting cluster %s: %s", cluster_template, err)
                 return
-        if hasattr(cluster,extra):
+        if hasattr(cluster,"extra"):
             print("Cluster has attr extra")
             cluster.extra["labels"] = labels
         else:

--- a/elasticluster/subcommands.py
+++ b/elasticluster/subcommands.py
@@ -174,7 +174,6 @@ class Start(AbstractCommand):
         """
         Starts a new cluster.
         """
-        print(self.params)
         cluster_template = self.params.cluster
         if self.params.cluster_name:
             cluster_name = self.params.cluster_name

--- a/elasticluster/subcommands.py
+++ b/elasticluster/subcommands.py
@@ -210,7 +210,7 @@ class Start(AbstractCommand):
             except ConfigurationError as err:
                 log.error("Starting cluster %s: %s", cluster_template, err)
                 return
-        cluster.extra["labels"] = labels 
+        cluster.extra["labels"] = labels
         try:
             print("Starting cluster `{0}` with:".format(cluster.name))
             for cls in cluster.nodes:

--- a/elasticluster/subcommands.py
+++ b/elasticluster/subcommands.py
@@ -210,7 +210,7 @@ class Start(AbstractCommand):
             except ConfigurationError as err:
                 log.error("Starting cluster %s: %s", cluster_template, err)
                 return
-        cluster.labels = labels
+        
         try:
             print("Starting cluster `{0}` with:".format(cluster.name))
             for cls in cluster.nodes:

--- a/elasticluster/subcommands.py
+++ b/elasticluster/subcommands.py
@@ -208,7 +208,7 @@ class Start(AbstractCommand):
             except ConfigurationError as err:
                 log.error("Starting cluster %s: %s", cluster_template, err)
                 return
-        cluster.labels = cluster.params.labels
+        cluster.labels = self.params.labels
         try:
             print("Starting cluster `{0}` with:".format(cluster.name))
             for cls in cluster.nodes:


### PR DESCRIPTION
The concepts of labels and tags have diverged in GCE. Adding billing labels can help track costs of clusters. This pull request is a first attempt at providing billing labels to elasticluster users from the command line.

https://github.com/elasticluster/elasticluster/issues/702