### PR TITLE
Openstack Availability zone is being overwritten by Cluster config 

### DIFF
--- a/elasticluster/providers/openstack.py
+++ b/elasticluster/providers/openstack.py
@@ -487,11 +487,6 @@ class OpenStackCloudProvider(AbstractCloudProvider):
 
         vm_start_args = {}
 
-        if self.availability_zone:
-            log.debug("Starting node `%s` in availability zone `%s`.",
-                      node_name, self.availability_zone)
-            vm_start_args['availability_zone'] = self.availability_zone
-
         log.debug("Checking keypair `%s` ...", key_name)
         with OpenStackCloudProvider.__node_start_lock:
             self._check_keypair(key_name, public_key_path, private_key_path)
@@ -517,8 +512,12 @@ class OpenStackCloudProvider(AbstractCloudProvider):
                 .format(flavor, self._os_tenant_name, self._os_auth_url))
         flavor = flavors[0]
 
-        availability_zone = kwargs.pop('availability_zone','')
-        vm_start_args['availability_zone']=availability_zone
+        availability_zone = kwargs.pop('availability_zone', self.availability_zone)
+
+        if availability_zone:
+            log.debug("Starting node `%s` in availability zone `%s`.",
+                      node_name, availability_zone)
+            vm_start_args['availability_zone']=availability_zone
 
         network_ids = [net_id.strip()
                        for net_id in kwargs.pop('network_ids', '').split(',')]


### PR DESCRIPTION
Hello guys, I am having couple issues with Openstack configuration. I want to push my VM in an specific zone. However, the documentation explains that it should be in the [cloud section](https://elasticluster.readthedocs.io/en/latest/configure.html#valid-configuration-keys-for-openstack) but, when I deploy it gets overwritten and do not pass any value. 

my friend and I start debugging and find out a small bug. If I provide the availability zone from the cluster configuration it pass through and my VM gets deployed in the AZ that I set up. So to fix this issue here is the PR. 

However, discussing with my friend we find out that the AZ should not be set up from the `cloud` it does not look necessary then the AZ can be removed from the `__init__`. If you want to pass your AZ to other clusters, so then you can use the format `[cluster/<name>/<kind>]` as it explains in the [doc](https://elasticluster.readthedocs.io/en/latest/configure.html#cluster-section)