### PR TITLE
Improve GPU support - add consumer card and bug fixes for centos 7.9

### DIFF
--- a/elasticluster/share/playbooks/library/gpus
+++ b/elasticluster/share/playbooks/library/gpus
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Test run this module with::
 #

--- a/elasticluster/share/playbooks/library/gpus
+++ b/elasticluster/share/playbooks/library/gpus
@@ -181,7 +181,7 @@ def get_pci_gpu_info():
         if len(parts) < 3:
             # FIXME: log unexpected input!
             continue
-        if parts[1] == '0302' and parts[2] == '10de':
+        if (parts[1] == '0302' or parts[1] == '0300') and parts[2] == '10de':
             slot = _format_pci_slot(parts[0])
             vendor_name, model_name, model_name_long = get_pci_device_name(parts)
             result.append({

--- a/elasticluster/share/playbooks/roles/cuda.yml
+++ b/elasticluster/share/playbooks/roles/cuda.yml
@@ -11,6 +11,11 @@
         name: pciutils
         state: '{{ pkg_install_state }}'
 
+    - name: Install python 3
+      package:
+        name: python3
+        state: latest
+
     - name: Gather information about GPUs
       action: gpus
 

--- a/elasticluster/share/playbooks/roles/cuda.yml
+++ b/elasticluster/share/playbooks/roles/cuda.yml
@@ -11,6 +11,13 @@
         name: pciutils
         state: '{{ pkg_install_state }}'
 
+    - name: Update Kernel
+      package: 
+        name: 
+          - kernel
+          - kernel-devel
+        state: latest
+
     - name: Install python 3
       package:
         name: python3

--- a/elasticluster/share/playbooks/roles/cuda/tasks/main.yml
+++ b/elasticluster/share/playbooks/roles/cuda/tasks/main.yml
@@ -18,6 +18,10 @@
     name: nouveau
     state: present
 
+- name: Install NVIDIA Drivers
+  package:
+    name: nvidia-driver-latest-dkms
+    state: latest
 
 - name: Install CUDA packages
   package:


### PR DESCRIPTION
Hey, I had a couple of issues to get GPUs working on Openstack with a Centos 7.9 image (7.8 as well) and with gpus not recognizing _consumer_ cards. The changes are documented within the commit messages. 
