### PR TITLE
Adding Slurm JWT support

### DIFF
--- a/docs/playbooks.rst
+++ b/docs/playbooks.rst
@@ -338,6 +338,15 @@ Extra variables can be set by editing the `setup/` section:
      - Version of SLURM to install; valid values are ``17.02``, ``17.11``, and ``18.08``.
        **Note: only applicable to RHEL/CentOS 7 clusters,** in all other
        cases the version of SLURM provided by the Linux distribution is used.
+   * - ``slurm_authalttypes``
+     - ``not defined``
+     - Value of ``AuthAltTypes`` in ``slurm.conf``. By setting it to ``auth/jwt`` JSON
+       Web Tokens (JWT) Authentication. *Note* you also need to set ``slurm_authaltparameters``
+       to specify where it is stored.
+   * - ``slurm_authaltparameters``
+     - ``jwt_key=/etc/slurm/jwt.key``
+     - Value for ``ÀuthAltParameters```in ``slurm.conf``. Note the format that is needed, e.g. 
+       for JWTs to work. See `SLURM`_ for details.
 
 Note that the ``slurm_*`` extra variables need to be set *globally*
 (e.g., ``global_var_slurm_selectype``) because the SLURM configuration

--- a/elasticluster/share/playbooks/roles/slurm-common/templates/slurm.conf.j2
+++ b/elasticluster/share/playbooks/roles/slurm-common/templates/slurm.conf.j2
@@ -176,4 +176,10 @@ SlurmdLogFile=/var/log/slurm/slurmd.log
 AuthType=auth/munge
 CryptoType=crypto/munge
 
+{% if slurm_authalttypes is defined %}
+## Alternative authentication 
+AuthAltTypes={{slurm_authalttypes|default('auth/jwt')}}
+AuthAltParameters={{slurm_authaltparameters|default('jwt_key=/etc/slurm/jwt.key')}}
+{% endif %}
+
 DisableRootJobs=NO

--- a/elasticluster/share/playbooks/roles/slurm-master/tasks/create-jwtkey.yml
+++ b/elasticluster/share/playbooks/roles/slurm-master/tasks/create-jwtkey.yml
@@ -1,0 +1,15 @@
+# slurm-master/tasks/create-jwtkey.yml
+---
+
+- name: Create JWT key
+  command:
+   cmd: dd if=/dev/random of="{{ slurm_authaltparameters.split('=')[1] }}" bs=32 count=1
+   creates: "{{ slurm_authaltparameters.split('=')[1] }}"
+
+- name: Set correct JWT key rights
+  file:
+   path: "{{ slurm_authaltparameters.split('=')[1] }}"
+   owner: root
+   group: root
+   mode: '0600'
+

--- a/elasticluster/share/playbooks/roles/slurm-master/tasks/main.yml
+++ b/elasticluster/share/playbooks/roles/slurm-master/tasks/main.yml
@@ -10,6 +10,9 @@
 
 - import_tasks: install-slurmctld.yml
 
+- import_tasks: create-jwtkey.yml
+  when: (slurm_authalttypes is defined) and (slurm_authalttypes|lower == "auth/jwt")
+
 - name: Create cluster in accounting database
   tags:
     - slurm


### PR DESCRIPTION
For the Slurm REST API the JWT support is a nice feature. In this case the slurmrestd does not to be in the same munge and access can be granted by a token obtained from `scontrol token` on the master. I use the guideline as described in the documentation https://slurm.schedmd.com/jwt.html

I also took the liberty to add the two new options to the documentation.

PS: This is only possible since the slurm Centos EPEL repo was updated to include the slurmrestd and the dependencies.