### PR TITLE
iRODS icommands

### DIFF
--- a/elasticluster/share/playbooks/main.yml
+++ b/elasticluster/share/playbooks/main.yml
@@ -73,6 +73,7 @@
 - import_playbook: roles/rstudio.yml
 - import_playbook: roles/samba.yml
 - import_playbook: roles/docker.yml
+- import_playbook: roles/irods.yml
 
 # Jupyter installation comes last, to allow it to pick up any SW that's been
 # installed so far (e.g., for kernels, or for ipyparallel)

--- a/elasticluster/share/playbooks/roles/irods.yml
+++ b/elasticluster/share/playbooks/roles/irods.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Install iRODS
+  hosts: irods
+  tags:
+    - irods
+
+  roles:
+    - role: irods

--- a/elasticluster/share/playbooks/roles/irods/tasks/init-Debian.yml
+++ b/elasticluster/share/playbooks/roles/irods/tasks/init-Debian.yml
@@ -6,15 +6,8 @@
     state: present
 
 - name: add iRODS repository
-  apt_repository:
-    repo: deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main
+  ansible.builtin.apt_repository:
+    repo: deb [arch=amd64] https://packages.irods.org/apt/ {{ansible_distribution_release}} main
     state: present
+    update_cache: true
     filename: renci-irods
-  register: _irods_add_apt_repo
-
-- name: update APT cache
-  apt:
-    update_cache: yes
-    cache_valid_time: 86400
-    allow_unauthenticated: '{{ not insecure_https_downloads|default("no")|bool }}'
-  when: '_irods_add_apt_repo is changed'

--- a/elasticluster/share/playbooks/roles/irods/tasks/init-Debian.yml
+++ b/elasticluster/share/playbooks/roles/irods/tasks/init-Debian.yml
@@ -1,0 +1,20 @@
+---
+
+- name: Add Apt signing key for iRODS from the iRODS Consortium
+  ansible.builtin.apt_key:
+    url: https://packages.irods.org/irods-signing-key.asc
+    state: present
+
+- name: add iRODS repository
+  apt_repository:
+    repo: deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main
+    state: present
+    filename: renci-irods
+  register: _irods_add_apt_repo
+
+- name: update APT cache
+  apt:
+    update_cache: yes
+    cache_valid_time: 86400
+    allow_unauthenticated: '{{ not insecure_https_downloads|default("no")|bool }}'
+  when: '_irods_add_apt_repo is changed'

--- a/elasticluster/share/playbooks/roles/irods/tasks/init-RedHat.yml
+++ b/elasticluster/share/playbooks/roles/irods/tasks/init-RedHat.yml
@@ -7,7 +7,7 @@
 
 - name: Add iRODS YUM repository
   yum_repository:
-    name: RENCI iRODS Repository
+    name: renci-irods
     description: iRODS Consortium YUM repo
     baseurl: https://packages.irods.org/yum/pool/centos$releasever/$basearch
     enabled: yes

--- a/elasticluster/share/playbooks/roles/irods/tasks/init-RedHat.yml
+++ b/elasticluster/share/playbooks/roles/irods/tasks/init-RedHat.yml
@@ -1,0 +1,17 @@
+---
+
+- name: Add rpm key for iRODS
+  rpm_key:
+    state: present
+    key: https://packages.irods.org/irods-signing-key.asc
+
+- name: Add iRODS YUM repository
+  yum_repository:
+    name: RENCI iRODS Repository
+    description: iRODS Consortium YUM repo
+    baseurl: https://packages.irods.org/yum/pool/centos$releasever/$basearch
+    enabled: yes
+    gpgcheck: yes
+    gpgcheck: yes
+    gpgkey: https://packages.irods.org/irods-signing-key.asc
+   

--- a/elasticluster/share/playbooks/roles/irods/tasks/main.yml
+++ b/elasticluster/share/playbooks/roles/irods/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Perform distribution-dependent steps
+  include_tasks: 'init-{{ansible_os_family}}.yml'
+
+- name: Install iRODS iCommands
+  package:
+    name: irods-icommands
+    state: latest


### PR DESCRIPTION
The Integrated Rule-Oriented Data System (iRODS) is open source data management software, see https://irods.org and https://github.com/irods/irods

I did not integrate the hole infrastructure to provide an iRODS service inside the cluster but just to install the iCommands with a deployment. This allows you to connect to an existing iRODS. Sooner or later I might get around to do the rest ;).

This only works for Centos <= 7 and Ubunto <= bionic as the Server https://packages.irods.org does not support newer versions. 

If I have more time I'll have a look at https://github.com/irods/irods_client_icommands#install for a manual isntallation